### PR TITLE
Add bfn method output

### DIFF
--- a/datachallenges/dc_ose_2021/datachallenge.toml
+++ b/datachallenges/dc_ose_2021/datachallenge.toml
@@ -15,3 +15,7 @@ var = "rec_ssh"
 [methods.duacs]
 url = "https://s3.eu-west-2.wasabisys.com/oceanbench-data-registry/dvc/95/7d74696fbf5f2b6d0c528757951b8a"
 var = "ssh"
+
+[methods.bfn]
+url = "https://s3.eu-west-2.wasabisys.com/oceanbench-data-registry/dvc/29/6781b126d905e98b82dac9bcecf57e"
+var = "ssh"

--- a/datachallenges/dc_ose_2021/dvc.lock
+++ b/datachallenges/dc_ose_2021/dvc.lock
@@ -235,3 +235,79 @@ stages:
       hash: md5
       md5: d1acd78b1829637e4bee155b9f85ea9c
       size: 30
+  method_output@bfn:
+    cmd: wget 
+      https://s3.eu-west-2.wasabisys.com/oceanbench-data-registry/dvc/29/6781b126d905e98b82dac9bcecf57e
+      -nc -O 'data/method_outputs/bfn.nc'
+    outs:
+    - path: data/method_outputs/bfn.nc
+      hash: md5
+      md5: 296781b126d905e98b82dac9bcecf57e
+      size: 700845764
+  interp_on_track@bfn:
+    cmd: qf_alongtrack_lambdax_from_map -cd . -cn stage_configs 'to_run=[interp_on_track]'
+      'stages.interp_on_track.grid_var=ssh' 'stages.method=bfn'
+    deps:
+    - path: data/method_outputs/bfn.nc
+      hash: md5
+      md5: 296781b126d905e98b82dac9bcecf57e
+      size: 700845764
+    - path: data/prepared/c2.nc
+      hash: md5
+      md5: fb8bf253e87be431b298b136dde80d99
+      size: 1397837
+    params:
+      datachallenge.toml:
+        pipelines.diagnostic.qf_alongtrack_lambdax_from_map: 0.0.1
+      stage_configs.yaml:
+        stages.interp_on_track:
+          _target_: qf_interp_grid_on_track.run
+          _partial_: true
+          track_path: ${..filter_and_merge.output_path}
+          grid_path: data/method_outputs/${..method}.nc
+          grid_var: ???
+          output_path: data/method_outputs/${..method}_on_track.nc
+          _skip_val: false
+    outs:
+    - path: data/method_outputs/bfn_on_track.nc
+      hash: md5
+      md5: 3d31f6fed2f9786b7f69d0a8784abaec
+      size: 1587360
+  compute_lambdax@bfn:
+    cmd: qf_alongtrack_lambdax_from_map -cd . -cn stage_configs 'to_run=[lambdax]'
+      'stages.interp_on_track.grid_var=ssh' 'stages.method=bfn'
+    deps:
+    - path: data/method_outputs/bfn_on_track.nc
+      hash: md5
+      md5: 3d31f6fed2f9786b7f69d0a8784abaec
+      size: 1587360
+    - path: data/prepared/c2.nc
+      hash: md5
+      md5: fb8bf253e87be431b298b136dde80d99
+      size: 1397837
+    params:
+      datachallenge.toml:
+        pipelines.diagnostic.qf_alongtrack_lambdax_from_map: 0.0.1
+      stage_configs.yaml:
+        stages.lambdax:
+          _target_: alongtrack_lambdax.main_api
+          _partial_: true
+          study_path: ${..interp_on_track.output_path}
+          study_var: ${..interp_on_track.grid_var}
+          ref_path: ${..filter_and_merge.output_path}
+          ref_var: ssh
+          delta_t: 0.9434
+          velocity: 6.77
+          length_scale: 1000.0
+          segment_overlapping: 0.25
+          output_lambdax_path: data/metrics/lambdax_${..method}.json
+          output_psd_path: data/method_outputs/psd_${..method}.json
+    outs:
+    - path: data/method_outputs/psd_bfn.json
+      hash: md5
+      md5: 4fc2fe5ec017bde54fe1e5b47a37873f
+      size: 7957
+    - path: data/metrics/lambdax_bfn.json
+      hash: md5
+      md5: 0065df0b4369de75e123600cb5470c8c
+      size: 30

--- a/datachallenges/dc_ose_2021/report.md
+++ b/datachallenges/dc_ose_2021/report.md
@@ -3,5 +3,6 @@ Spatial scales resolved $\lambda_x$ \n
 | Path                  | lambdax   |
 |-----------------------|-----------|
 | lambdax_4dvarnet.json | 105.1696  |
+| lambdax_bfn.json      | 117.6239  |
 | lambdax_duacs.json    | 154.19603 |
 


### PR DESCRIPTION
Example pull request for adding a method.

Adding the section in the `datachallenge.toml` updates the dag from:

```mermaid
flowchart TD
        node1["compute_lambdax@4dvarnet"]
        node2["compute_lambdax@duacs"]
        node3["filter_and_merge_ref"]
        node4["interp_on_track@4dvarnet"]
        node5["interp_on_track@duacs"]
        node6["method_output@4dvarnet"]
        node7["method_output@duacs"]
        node3-->node1
        node3-->node2
        node3-->node4
        node3-->node5
        node4-->node1
        node5-->node2
        node6-->node4
        node7-->node5
        node8["fetch_reference_data"]-->node3
```

to 
```mermaid
flowchart TD
        node1["compute_lambdax@4dvarnet"]
        node2["compute_lambdax@bfn"]
        node3["compute_lambdax@duacs"]
        node4["filter_and_merge_ref"]
        node5["interp_on_track@4dvarnet"]
        node6["interp_on_track@bfn"]
        node7["interp_on_track@duacs"]
        node8["method_output@4dvarnet"]
        node9["method_output@bfn"]
        node10["method_output@duacs"]
        node4-->node1
        node4-->node2
        node4-->node3
        node4-->node5
        node4-->node6
        node4-->node7
        node5-->node1
        node6-->node2
        node7-->node3
        node8-->node5
        node9-->node6
        node10-->node7
        node11["fetch_reference_data"]-->node4
```

dvc is able to recognize that the graph has changed:

```bash
% dvc status
WARNING: stage: 'fetch_reference_data' is frozen. Its dependencies are not going to be shown in the status output.
method_output@bfn:
        changed outs:
                modified:           data/method_outputs/bfn.nc
interp_on_track@bfn:
        changed deps:
                modified:           data/prepared/c2.nc
                modified:           data/method_outputs/bfn.nc
                new:                datachallenge.toml
                new:                stage_configs.yaml
        changed outs:
                deleted:            data/method_outputs/bfn_on_track.nc
compute_lambdax@bfn:
        changed deps:
                modified:           data/prepared/c2.nc
                deleted:            data/method_outputs/bfn_on_track.nc
                new:                datachallenge.toml
                new:                stage_configs.yaml
        changed outs:
                deleted:            data/method_outputs/psd_bfn.json
                deleted:            data/metrics/lambdax_bfn.json
```

By pushing on a branch starting with `dc_ose_2021/` a github action workflow has started to try to keep the datachallenge up to date. 

Another way would be to compute the missing artefacts locally and push them, the workflow would then have nothing to do except validate that everything is up to date
